### PR TITLE
Add PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,23 +10,15 @@ jobs:
   deploy:
     needs: [test, lint]
     name: Deploy to PyPI
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
-    runs-on: ubuntu-latest
     steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
-
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - run: echo "SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)" >> $GITHUB_ENV
+      - run: uv build
+      - uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          python-version: 3.11
-          cache: 'pip' # caching pip dependencies
-      - name: Install build dependencies
-        run: python -m pip install build twine
-
-      - name: Build distributions
-        run: python -m build
-
-      - name: Publish package to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+          packages-dir: ./dist

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: Build distribution
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  test:
+    uses: ./.github/workflows/test.yml
+  deploy:
+    needs: [test, lint]
+    name: Deploy to PyPI
+    permissions:
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+          cache: 'pip' # caching pip dependencies
+      - name: Install build dependencies
+        run: python -m pip install build twine
+
+      - name: Build distributions
+        run: python -m build
+
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to automatically publish package to PyPI on release
- Includes dependency on test workflow to ensure quality before publishing  
- Uses trusted publishing with OIDC tokens for secure PyPI authentication

## Test plan
- [x] YAML syntax validated locally
- [ ] Test workflow triggers on release creation
- [ ] Confirm PyPI publishing works with trusted publishing setup

🤖 Generated with [Claude Code](https://claude.ai/code)