### PR TITLE
issue-14

### DIFF
--- a/src/render_engine_cli/cli.py
+++ b/src/render_engine_cli/cli.py
@@ -25,8 +25,6 @@ from render_engine_cli.utils import (
     validate_module_site,
 )
 
-click.echo("[bold green]In the new CLI[/bold green]", color=True)
-
 
 @click.group()
 def app():
@@ -87,9 +85,10 @@ def init(template: str, extra_context: str, no_input: bool, output_dir: Path, co
     try:
         from cookiecutter.main import cookiecutter
     except ImportError:
-        click.echo(
+        click.secho(
             "You need to install cookiecutter to use this command. Run `pip install cookiecutter` to install it.",
             err=True,
+            fg="red",
         )
         raise click.Exit(0)
     extra_context = json.loads(extra_context) if extra_context else None

--- a/src/render_engine_cli/utils.py
+++ b/src/render_engine_cli/utils.py
@@ -48,7 +48,9 @@ class CliConfig:
         try:
             with open(config_file) as stored_config_file:
                 try:
-                    stored_config = toml.load(stored_config_file).get("tool.render-engine", {}).get("cli", {})
+                    stored_config = (
+                        toml.load(stored_config_file).get("tool", {}).get("render-engine", {}).get("cli", {})
+                    )
                 except TomlDecodeError as exc:
                     click.echo(f"Encountered an error while parsing {config_file} - {exc}.")
                 else:

--- a/src/render_engine_cli/utils.py
+++ b/src/render_engine_cli/utils.py
@@ -52,7 +52,10 @@ class CliConfig:
                         toml.load(stored_config_file).get("tool", {}).get("render-engine", {}).get("cli", {})
                     )
                 except TomlDecodeError as exc:
-                    click.echo(f"Encountered an error while parsing {config_file} - {exc}.")
+                    click.echo(
+                        f"{click.style(f'Encountered an error while parsing {config_file}', fg='red')}\n{exc}\n",
+                        err=True,
+                    )
                 else:
                     click.echo(f"Config loaded from {config_file}")
         except FileNotFoundError:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,5 @@
 import frontmatter
 import pytest
-import toml
 from render_engine import Collection, Page, Site
 
 from render_engine_cli.utils import (
@@ -106,12 +105,14 @@ def test_split_args_error_handling():
 
 def test_config_loading_with_valid_config(tmp_path, monkeypatch):
     """Tests config loading from pyproject.toml (2025.5.1b1 feature)"""
-    config_content = {
-        "tool.render-engine": {"cli": {"module": "myapp", "site": "MySite", "collection": "MyCollection"}}
-    }
-
+    config_content = """
+[tool.render-engine.cli]
+module = "myapp"
+site = "MySite"
+collection = "MyCollection"
+"""
     config_file = tmp_path / "pyproject.toml"
-    config_file.write_text(toml.dumps(config_content))
+    config_file.write_text(config_content)
 
     # Change to temp directory for config loading test
     monkeypatch.chdir(tmp_path)


### PR DESCRIPTION
Fixes #14

- Uses the correct dictionary for `pyproject.toml` configuration
- Improves testing of `CliConfig` by using a TOML file rather than dumping a dictionary with `toml.dump`
- Removes debug print
- Adds color formatting to error messages.