### PR TITLE
Add the ability to set the editor for `new-entry`. Formatting fixes.

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ from render_engine_cli.utils import (
     create_collection_entry,
     display_filtered_templates,
     get_available_themes,
+    get_editor,
     get_site_content_paths,
     split_args,
     split_module_site,
@@ -232,3 +233,12 @@ def test_display_filtered_templates():
         # Check that the table was created with filtered results
         call_args = mock_rprint.call_args[0][0]
         assert call_args.title == "Test Templates"
+
+
+@pytest.mark.parametrize(
+    "selection, expected", [("none", None), ("DEFAULT", "vim"), ("default", "vim"), ("nano", "nano")]
+)
+def test_get_editor(selection, expected, monkeypatch):
+    """Test the get_editor callback"""
+    monkeypatch.setattr("render_engine_cli.utils.getenv", lambda *_: "vim")
+    assert get_editor(None, None, value=selection) == expected

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -127,7 +127,7 @@ def test_new_entry_command_success(runner, test_site_module, monkeypatch):
     """Tests new_entry command with valid parameters"""
     tmp_path, module_site = test_site_module
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr("render_engine_cli.cli.os.getenv", lambda *_: {})
+    monkeypatch.setattr("render_engine_cli.utils.getenv", lambda *_: {})
 
     # Create content directory
     content_dir = tmp_path / "content"
@@ -172,7 +172,7 @@ def test_new_entry_command_with_args(runner, test_site_module, monkeypatch):
     """Tests new_entry command with --args parameter"""
     tmp_path, module_site = test_site_module
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr("render_engine_cli.cli.os.getenv", lambda *_: {})
+    monkeypatch.setattr("render_engine_cli.utils.getenv", lambda *_: {})
 
     content_dir = tmp_path / "content"
     content_dir.mkdir()
@@ -268,7 +268,7 @@ def test_new_entry_date_options(options, expected, monkeypatch, test_site_module
 
     tmp_path, module_site = test_site_module
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr("render_engine_cli.cli.os.getenv", lambda *_: {})
+    monkeypatch.setattr("render_engine_cli.utils.getenv", lambda *_: {})
     monkeypatch.setattr("render_engine_cli.cli.create_collection_entry", mock_create_collection_entry)
     content_dir = tmp_path / "content"
     content_dir.mkdir()

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -127,7 +127,6 @@ def test_new_entry_command_success(runner, test_site_module, monkeypatch):
     """Tests new_entry command with valid parameters"""
     tmp_path, module_site = test_site_module
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr("render_engine_cli.utils.getenv", lambda *_: {})
 
     # Create content directory
     content_dir = tmp_path / "content"
@@ -172,7 +171,6 @@ def test_new_entry_command_with_args(runner, test_site_module, monkeypatch):
     """Tests new_entry command with --args parameter"""
     tmp_path, module_site = test_site_module
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr("render_engine_cli.utils.getenv", lambda *_: {})
 
     content_dir = tmp_path / "content"
     content_dir.mkdir()
@@ -268,7 +266,6 @@ def test_new_entry_date_options(options, expected, monkeypatch, test_site_module
 
     tmp_path, module_site = test_site_module
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr("render_engine_cli.utils.getenv", lambda *_: {})
     monkeypatch.setattr("render_engine_cli.cli.create_collection_entry", mock_create_collection_entry)
     content_dir = tmp_path / "content"
     content_dir.mkdir()


### PR DESCRIPTION
Resolves issue #16 

- Adds ability to set the editor for `new-entry` from the command line
- Adds ability to configure the default editor for `new-entry`
- Converts `CliConfig` to `dataclass`
- Formatting issues
- Missing doc strings