### PR TITLE
CLI improvements

### DIFF
--- a/src/render_engine_cli/cli.py
+++ b/src/render_engine_cli/cli.py
@@ -18,6 +18,7 @@ from render_engine_cli.utils import (
     get_editor,
     get_site,
     get_site_content_paths,
+    handle_content_file,
     remove_output_folder,
     split_args,
     split_module_site,
@@ -207,9 +208,11 @@ def serve(module_site: str, clean: bool, reload: bool, port: int):
 )
 @click.option(
     "--content-file",
-    type=click.File("r"),
+    type=click.STRING,
+    callback=handle_content_file,
     default=None,
-    help="Path to a file containing the desired content. Either this or `--content` may be provided but not both",
+    help="Path to a file containing the desired content. Using 'stdin' will ask you to enter the content in "
+    "the terminal. Either this or `--content` may be provided but not both",
 )
 @click.option(
     "-t",
@@ -259,7 +262,7 @@ def new_entry(
     module_site: str,
     collection: str,
     content: str,
-    content_file: click.File,
+    content_file: str,
     title: str,
     slug: str,
     include_date: bool,
@@ -308,7 +311,7 @@ def new_entry(
     if content and content_file:
         raise TypeError("Both content and content_file provided. At most one may be provided.")
     if content_file:
-        content = content_file.read()
+        content = content_file
     entry = create_collection_entry(content=content or "", collection=_collection, **parsed_args)
     if title:
         # If we had a title earlier this is where we replace the default that is added by the template handler with

--- a/src/render_engine_cli/event.py
+++ b/src/render_engine_cli/event.py
@@ -124,9 +124,12 @@ class ServerEventHandler:
 
         console.print(f"[yellow]Serving {self.output_path}[/yellow]")
         while not self.stop_watcher():
-            if self.dirs_to_watch:
-                for _ in watchfiles.watch(*self.dirs_to_watch):
-                    self.rebuild()
+            try:
+                if self.dirs_to_watch:
+                    for _ in watchfiles.watch(*self.dirs_to_watch):
+                        self.rebuild()
+            except KeyboardInterrupt:
+                break
 
     def __enter__(self):
         """Starting Context manager for the class"""

--- a/src/render_engine_cli/utils.py
+++ b/src/render_engine_cli/utils.py
@@ -221,7 +221,6 @@ def handle_content_file(ctx: click.Context, param: click.Option, value: str) -> 
         click.secho('Please enter the content. To finish, put a "." on a blank line.', fg="green")
         while (line := input("")) != ".":
             content.append(line)
-        print(content)
         return "\n".join(content)
     path = Path(value)
     if not path.exists:

--- a/src/render_engine_cli/utils.py
+++ b/src/render_engine_cli/utils.py
@@ -223,7 +223,7 @@ def handle_content_file(ctx: click.Context, param: click.Option, value: str) -> 
             content.append(line)
         return "\n".join(content)
     path = Path(value)
-    if not path.exists:
+    if not path.exists():
         raise click.exceptions.BadParameter(
             f'Either the path to a file or "stdin" must be provided. {repr(value)} is invalid.'
         )

--- a/src/render_engine_cli/utils.py
+++ b/src/render_engine_cli/utils.py
@@ -212,3 +212,20 @@ def get_editor(ctx: click.Context, param: click.Option, value: str) -> str | Non
             return None
         case _:
             return value
+
+
+def handle_content_file(ctx: click.Context, param: click.Option, value: str) -> str | None:
+    """Handle the content file"""
+    if value == "stdin":
+        content = list()
+        click.secho('Please enter the content. To finish, put a "." on a blank line.', fg="green")
+        while (line := input("")) != ".":
+            content.append(line)
+        print(content)
+        return "\n".join(content)
+    path = Path(value)
+    if not path.exists:
+        raise click.exceptions.BadParameter(
+            f'Either the path to a file or "stdin" must be provided. {repr(value)} is invalid.'
+        )
+    return path.read_text()


### PR DESCRIPTION
- Fixes #17 by allowing entry of content from STDIN in `new-entry`
- Fixes #19 by exiting the server when `CTRL-C` is pressed once when running `serve --reload`