### PR TITLE
Tab Completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,29 +52,29 @@ For a smoother CLI experience, Render Engine CLI provides built-in shell complet
 for `bash`, `zsh`, and `fish`. This allows you to quickly autocomplete commands, options,
 and arguments directly in your terminal.
 
-- **Bash**
+### Bash
 
-  Add this to your `~/.bashrc`:
+Add this to your `~/.bashrc`:
 
-  ```bash
-  eval "$(_RENDER_ENGINE_COMPLETE=bash_source render-engine)"
-  ```
+```sh
+eval "$(_RENDER_ENGINE_COMPLETE=bash_source render-engine)"
+```
 
-- **Zsh**
+### Zsh
 
-  Add this to your `~/.zshrc`:
+Add this to your `~/.zshrc`:
 
-  ```zsh
-  eval "$(_RENDER_ENGINE_COMPLETE=zsh_source render-engine)"
-  ```
+```sh
+eval "$(_RENDER_ENGINE_COMPLETE=zsh_source render-engine)"
+```
 
-- **Fish**
+### Fish
 
-  Add this to your `~/.config/fish/completions/render-engine.fish`:
+Add this to your `~/.config/fish/completions/render-engine.fish`:
 
-  ```fish
-  eval (env _RENDER_ENGINE_COMPLETE=fish_source render-engine)
-  ```
+```sh
+eval (env _RENDER_ENGINE_COMPLETE=fish_source render-engine)
+```
 
 After adding the appropriate line to your shell configuration file, restart your shell or source the configuration file to enable completion.
 


### PR DESCRIPTION
# Issue Link: #35 

Adds documentation for enabling shell completion (bash, zsh, fish).

- Zsh
<img width="925" height="301" alt="zsh" src="https://github.com/user-attachments/assets/c2eaba97-497c-44fb-af84-4a5cc7a95e08" />

- Bash

<img width="980" height="169" alt="bash" src="https://github.com/user-attachments/assets/c5770583-293a-4951-8b5e-badd2dcc0d31" />

- Fish

<img width="1184" height="244" alt="fish" src="https://github.com/user-attachments/assets/ce251143-d30b-44de-8791-8e31100bff69" />
